### PR TITLE
feat: expose first-class schema discovery api

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,23 @@ Use jq-like selectors to narrow the output:
 
 Patterns compose: `--schema=.deploy..lambda`, `--schema=.*.list`
 
+For custom schema commands or integrations, use `selectSchema` as the stable schema discovery API:
+
+```typescript
+import { generateSchema, selectSchema } from 'argc'
+
+const selected = selectSchema(schema, '.user.create', { depth: 2 })
+
+console.log(
+	generateSchema(selected.schema, {
+		name: 'myapp',
+		description: 'My CLI app',
+	}),
+)
+```
+
+`selectSchema` owns selector parsing, router matching, subset construction, root selector behavior, and empty-match reporting. Lower-level helpers are also exported for advanced use: `parseSchemaSelector`, `matchSchemaSelector`, and `buildSchemaSubset`.
+
 ## Hook Events for Agent Runtimes
 
 CLI stdout is for the agent reading the command result. Hook events are for the system around the agent: runtime logs, UI rendering, progress panels, audit trails, or tool-call replay.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,11 +28,7 @@ import {
 	generateSchemaHintExample,
 	generateSchemaOutline,
 } from './schema'
-import {
-	buildSchemaSubset,
-	matchSchemaSelector,
-	parseSchemaSelector,
-} from './schema-selector'
+import { selectSchema, type SchemaSelectionResult } from './schema-selector'
 import {
 	expandHome,
 	readStdin,
@@ -228,8 +224,7 @@ export class CLI<
 		// Handle --schema (root only, for AI agents)
 		if (parsed.flags.schema) {
 			if (isRootLevel) {
-				let selectorMatches: ReturnType<typeof matchSchemaSelector> | null =
-					null
+				let selection: SchemaSelectionResult | null = null
 				let schemaOutput = generateSchema(this.schema, {
 					name: this.options.name,
 					description: this.options.description,
@@ -239,10 +234,8 @@ export class CLI<
 					typeof parsed.flags.schema === 'string' ? parsed.flags.schema : null
 				if (selectorValue) {
 					try {
-						const steps = parseSchemaSelector(selectorValue)
-						selectorMatches = matchSchemaSelector(this.schema, steps)
-						const subset = buildSchemaSubset(this.schema, selectorMatches, 1)
-						schemaOutput = generateSchema(subset, {
+						selection = selectSchema(this.schema, selectorValue, { depth: 1 })
+						schemaOutput = generateSchema(selection.schema, {
 							name: this.options.name,
 							description: this.options.description,
 							globals: this.options.globals,
@@ -263,9 +256,10 @@ export class CLI<
 					)
 					console.log()
 					const outlineSchema =
-						selectorMatches === null
+						selection === null
 							? this.schema
-							: buildSchemaSubset(this.schema, selectorMatches, 2)
+							: selectSchema(this.schema, selection.selector, { depth: 2 })
+									.schema
 					for (const line of generateSchemaOutline(outlineSchema, 2)) {
 						console.log(line)
 					}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+	buildSchemaSubset,
+	matchSchemaSelector,
+	parseSchemaSelector,
+	selectSchema,
+} from './index'
+
+describe('public exports', () => {
+	test('exports schema discovery helpers from the main entry', () => {
+		expect(typeof parseSchemaSelector).toBe('function')
+		expect(typeof matchSchemaSelector).toBe('function')
+		expect(typeof buildSchemaSubset).toBe('function')
+		expect(typeof selectSchema).toBe('function')
+	})
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,24 @@ export { complete, generateCompletionScript } from './complete'
 export type { CompletionContext } from './complete'
 export { c, CommandBuilder, group, GroupBuilder } from './command'
 export { parseArgv } from './parser'
-export { generateSchema, generateSchemaHintExample, generateSchemaOutline } from './schema'
+export {
+	generateSchema,
+	generateSchemaHintExample,
+	generateSchemaOutline,
+} from './schema'
+export {
+	buildSchemaSubset,
+	matchSchemaSelector,
+	parseSchemaSelector,
+	selectSchema,
+	sliceRouter,
+} from './schema-selector'
+export type {
+	SchemaSelectionOptions,
+	SchemaSelectionResult,
+	SelectorMatch,
+	SelectorStep,
+} from './schema-selector'
 export type {
 	AnyCommand,
 	AnyGroup,

--- a/src/schema-selector-subset.test.ts
+++ b/src/schema-selector-subset.test.ts
@@ -3,7 +3,12 @@ import { describe, expect, test } from 'bun:test'
 import * as v from 'valibot'
 
 import { c, group } from './command'
-import { buildSchemaSubset, matchSchemaSelector, parseSchemaSelector } from './schema-selector'
+import {
+	buildSchemaSubset,
+	matchSchemaSelector,
+	parseSchemaSelector,
+	selectSchema,
+} from './schema-selector'
 import { isGroup, isCommand } from './types'
 
 const s = toStandardJsonSchema
@@ -47,25 +52,80 @@ describe('buildSchemaSubset', () => {
 		const aws = children.children['aws']
 		const vercel = children.children['vercel']
 		expect(isGroup(aws)).toBe(true)
-		expect(Object.keys((aws as ReturnType<typeof group>)['~argc.group'].children)).toEqual([])
+		expect(
+			Object.keys((aws as ReturnType<typeof group>)['~argc.group'].children),
+		).toEqual([])
 		expect(isCommand(vercel)).toBe(true)
 	})
 
 	test('scopes to nested group with one-level children', () => {
-		const matches = matchSchemaSelector(schema, parseSchemaSelector('.deploy.aws'))
+		const matches = matchSchemaSelector(
+			schema,
+			parseSchemaSelector('.deploy.aws'),
+		)
 		const subset = buildSchemaSubset(schema, matches, 1)
 		const deploy = (subset as Record<string, unknown>)['deploy']
 		expect(isGroup(deploy)).toBe(true)
-		const deployChildren = (deploy as ReturnType<typeof group>)['~argc.group'].children
+		const deployChildren = (deploy as ReturnType<typeof group>)['~argc.group']
+			.children
 		const aws = deployChildren['aws']
 		expect(isGroup(aws)).toBe(true)
-		const awsChildren = (aws as ReturnType<typeof group>)['~argc.group'].children
+		const awsChildren = (aws as ReturnType<typeof group>)['~argc.group']
+			.children
 		expect(Object.keys(awsChildren)).toEqual(['lambda', 's3'])
 	})
 
 	test('scopes to set selection', () => {
-		const matches = matchSchemaSelector(schema, parseSchemaSelector('.{user,plain}'))
-		const subset = buildSchemaSubset(schema, matches, 1) as Record<string, unknown>
+		const matches = matchSchemaSelector(
+			schema,
+			parseSchemaSelector('.{user,plain}'),
+		)
+		const subset = buildSchemaSubset(schema, matches, 1) as Record<
+			string,
+			unknown
+		>
 		expect(Object.keys(subset)).toEqual(['user', 'plain'])
+	})
+})
+
+describe('selectSchema', () => {
+	test('returns a focused schema and match metadata', () => {
+		const result = selectSchema(schema, '.deploy.aws', { depth: 1 })
+
+		expect(result.selector).toBe('.deploy.aws')
+		expect(result.empty).toBe(false)
+		expect(result.matches.map((match) => match.path)).toEqual([
+			['deploy', 'aws'],
+		])
+
+		const deploy = (result.schema as Record<string, unknown>)['deploy']
+		expect(isGroup(deploy)).toBe(true)
+		const aws = (deploy as ReturnType<typeof group>)['~argc.group'].children[
+			'aws'
+		]
+		expect(isGroup(aws)).toBe(true)
+		expect(
+			Object.keys((aws as ReturnType<typeof group>)['~argc.group'].children),
+		).toEqual(['lambda', 's3'])
+	})
+
+	test('uses depth 1 by default', () => {
+		const result = selectSchema(schema, '.deploy')
+		const deploy = (result.schema as Record<string, unknown>)['deploy']
+		expect(isGroup(deploy)).toBe(true)
+		const aws = (deploy as ReturnType<typeof group>)['~argc.group'].children[
+			'aws'
+		]
+		expect(isGroup(aws)).toBe(true)
+		expect(
+			Object.keys((aws as ReturnType<typeof group>)['~argc.group'].children),
+		).toEqual([])
+	})
+
+	test('marks valid selectors with no matches as empty', () => {
+		const result = selectSchema(schema, '.missing')
+		expect(result.empty).toBe(true)
+		expect(result.matches).toEqual([])
+		expect(result.schema).toEqual({})
 	})
 })

--- a/src/schema-selector.ts
+++ b/src/schema-selector.ts
@@ -16,6 +16,18 @@ export type SelectorMatch = {
 	node: Router
 }
 
+export type SchemaSelectionOptions = {
+	depth?: number
+}
+
+export type SchemaSelectionResult = {
+	selector: string
+	steps: SelectorStep[]
+	matches: SelectorMatch[]
+	schema: Router
+	empty: boolean
+}
+
 export function parseSchemaSelector(input: string): SelectorStep[] {
 	if (!input) {
 		throw new Error('Selector is empty')
@@ -61,7 +73,10 @@ export function parseSchemaSelector(input: string): SelectorStep[] {
 	return steps
 }
 
-export function matchSchemaSelector(schema: Router, steps: SelectorStep[]): SelectorMatch[] {
+export function matchSchemaSelector(
+	schema: Router,
+	steps: SelectorStep[],
+): SelectorMatch[] {
 	if (steps.length === 0) {
 		return [{ path: [], node: schema }]
 	}
@@ -113,7 +128,11 @@ export function matchSchemaSelector(schema: Router, steps: SelectorStep[]): Sele
 	return current
 }
 
-export function buildSchemaSubset(schema: Router, matches: SelectorMatch[], depth: number): Router {
+export function buildSchemaSubset(
+	schema: Router,
+	matches: SelectorMatch[],
+	depth: number,
+): Router {
 	if (matches.length === 0) return {}
 	if (matches.some((match) => match.path.length === 0)) {
 		return sliceRouter(schema, depth)
@@ -126,6 +145,24 @@ export function buildSchemaSubset(schema: Router, matches: SelectorMatch[], dept
 	return root
 }
 
+export function selectSchema(
+	schema: Router,
+	selector: string,
+	options: SchemaSelectionOptions = {},
+): SchemaSelectionResult {
+	const steps = parseSchemaSelector(selector)
+	const matches = matchSchemaSelector(schema, steps)
+	const depth = options.depth ?? 1
+
+	return {
+		selector,
+		steps,
+		matches,
+		schema: buildSchemaSubset(schema, matches, depth),
+		empty: matches.length === 0,
+	}
+}
+
 export function sliceRouter(router: Router, depth: number): Router {
 	if (isCommand(router)) return router
 
@@ -134,7 +171,9 @@ export function sliceRouter(router: Router, depth: number): Router {
 			return group(router['~argc.group'].meta, {})
 		}
 		const children: Record<string, Router> = {}
-		for (const [name, child] of Object.entries(router['~argc.group'].children)) {
+		for (const [name, child] of Object.entries(
+			router['~argc.group'].children,
+		)) {
 			children[name] = sliceRouter(child, depth - 1)
 		}
 		return group(router['~argc.group'].meta, children)


### PR DESCRIPTION
## Summary

Implements schema discovery as a first-class public API instead of requiring downstream CLIs to vendor or manually compose selector internals.

- Adds `selectSchema(router, selector, { depth })` as the high-level schema discovery entrypoint.
- Publicly exports `selectSchema` plus low-level selector helpers and types from the main `argc` entry.
- Updates the built-in `--schema=<selector>` path to use `selectSchema` internally.
- Adds tests for focused selection metadata, default depth behavior, empty-match reporting, and public exports.
- Documents the stable `selectSchema` integration pattern for custom schema commands.

Fixes #7.

## Why

Agent-facing CLIs need focused schema discovery:

```bash
my-cli --schema=.group.command
my-cli --schema=..command
```

The selector/parser/matcher/subset logic already existed internally, but downstream packages could not rely on it as a public contract. This PR gives `argc` ownership of the schema discovery abstraction so provider CLIs can stay focused on provider commands, credentials, and diagnostics.

## Verification

- `bun test` ✅
- `bun run typecheck` ✅
- `bunx oxfmt --check src/schema-selector.ts src/index.ts src/cli.ts src/schema-selector-subset.test.ts src/index.test.ts` ✅

Note: full `bun run fmt:check` still reports existing formatting issues in unrelated files on this checkout (`examples/large.ts`, `src/command.ts`, `src/schema.ts`, etc.). I intentionally did not reformat unrelated files in this PR.
